### PR TITLE
Exposed TLD initialization as `get_tld_names`

### DIFF
--- a/src/tld/__init__.py
+++ b/src/tld/__init__.py
@@ -6,4 +6,4 @@ __copyright__ = '2013-2015 Artur Barseghyan'
 __license__ = 'GPL 2.0/LGPL 2.1'
 __all__ = ('get_tld', 'update_tld_names', 'Result',)
 
-from tld.utils import get_tld, update_tld_names, Result
+from tld.utils import get_tld, get_tld_names, update_tld_names, Result


### PR DESCRIPTION
We want to perform some custom string manipulation based on TLD's. In order to avoid hacks like eagerly running `get_tld('')`, we decided to expose the existing `init` function as a loader itself. In this PR:

- Added `get_tld_names` function (originally known as `init`) to fetch set of `tld_names`

**Notes:**

There are currently no tests for this functionality because:

- The function is being utilized by higher level functions already
- This is a personal request and might be outside of the scope of the project