### PR TITLE
Fix relative import in non-package for update-tls-names script

### DIFF
--- a/src/tld/__init__.py
+++ b/src/tld/__init__.py
@@ -11,4 +11,4 @@ __build__ = 0x000011
 __author__ = 'Artur Barseghyan'
 __copyright__ = '2013-2017 Artur Barseghyan'
 __license__ = 'GPL 2.0/LGPL 2.1'
-__all__ = ('get_tld', 'update_tld_names', 'Result',)
+__all__ = ('get_tld', 'get_tld_names', 'update_tld_names', 'Result',)

--- a/src/tld/bin/update-tld-names
+++ b/src/tld/bin/update-tld-names
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
-from ..commands.update_tld_names import main
+# We should have absolute imports here
+from tld.commands.update_tld_names import main
+
 
 if __name__ == "__main__":
     main()

--- a/src/tld/commands/update_tld_names.py
+++ b/src/tld/commands/update_tld_names.py
@@ -15,7 +15,7 @@ def main():
 
     :example:
 
-        python src/tld/update_tld_names.py
+        python src/tld/commands/update_tld_names.py
     """
 
     try:


### PR DESCRIPTION
Fixes #14

There seems too much indirection there:

 1. bin/update-tld-names
 2. tld.commands.update_tld_names
 3. tld.utils.update_tld_names

There might be a reason behind it (e.g. allowing to update names with
`python -m tld.commands.update_tld_names`) and probably out of scope for this
PR, so I left everything as it was.