### PR TITLE
Added base path override for local .dat file

### DIFF
--- a/src/tld/defaults.py
+++ b/src/tld/defaults.py
@@ -1,3 +1,5 @@
+import os
+
 __title__ = 'tld.defaults'
 __author__ = 'Artur Barseghyan'
 __copyright__ = '2013-2017 Artur Barseghyan'
@@ -5,6 +7,7 @@ __license__ = 'GPL 2.0/LGPL 2.1'
 __all__ = (
     'NAMES_SOURCE_URL',
     'NAMES_LOCAL_PATH',
+    'NAMES_LOCAL_PATH_PARENT',
     'DEBUG'
 )
 
@@ -14,5 +17,8 @@ NAMES_SOURCE_URL = 'http://mxr.mozilla.org/mozilla/source/netwerk/dns/src/' \
 
 # Relative path to store the local copy of Mozilla's effective TLD names file.
 NAMES_LOCAL_PATH = 'res/effective_tld_names.dat.txt'
+
+# Absolute base path that is prepended to NAMES_LOCAL_PATH
+NAMES_LOCAL_PATH_PARENT = os.path.dirname(__file__)
 
 DEBUG = False

--- a/src/tld/helpers.py
+++ b/src/tld/helpers.py
@@ -1,5 +1,7 @@
 import os
 
+from .conf import get_setting
+
 __title__ = 'tld.helpers'
 __author__ = 'Artur Barseghyan'
 __copyright__ = '2013-2017 Artur Barseghyan'
@@ -12,8 +14,9 @@ __all__ = (
 
 def project_dir(base):
     """Project dir."""
+    TLD_NAMES_LOCAL_PATH_PARENT = get_setting('NAMES_LOCAL_PATH_PARENT')
     return os.path.abspath(
-        os.path.join(os.path.dirname(__file__), base).replace('\\', '/')
+        os.path.join(TLD_NAMES_LOCAL_PATH_PARENT, base).replace('\\', '/')
     )
 
 

--- a/src/tld/test.py
+++ b/src/tld/test.py
@@ -2,10 +2,12 @@
 
 import copy
 import logging
+import os
 import unittest
 
 from . import defaults
 from .conf import get_setting, set_setting
+from .helpers import project_dir
 from .utils import get_tld, update_tld_names
 
 __title__ = 'tld.tests'
@@ -203,6 +205,14 @@ class TldTest(unittest.TestCase):
             res.append(_res)
         return res
 
+    @log_info
+    def test_6_override_full_names_path(self):
+        default = project_dir('dummy.txt')
+        override_base = '/tmp/test'
+        set_setting('NAMES_LOCAL_PATH_PARENT', override_base)
+        modified = project_dir('dummy.txt')
+        self.assertNotEqual(default, modified)
+        self.assertEqual(modified, os.path.abspath('/tmp/test/dummy.txt'))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This should allow any code to set the NAMES_LOCAL_PATH_PARENT setting before any subsequent calls to store (and reference) the res/effective_tld_names.dat.txt (NAMES_LOCAL_PATH) file in a different parent path than .../site-packages/tld

(There are issues when tld is installed as root, and then code runs without root priviledges as it can't update the file)

I tried to follow the same pattern (settings and defaults) as the existing code, rather than passing through an override path in the method calls,

There is a single simple test as well.