### PR TITLE
Fix wrongly swapped "new behaviour" and "old behaviour"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,7 +32,7 @@ are used for versioning (schema follows below):
 
         res = get_tld("http://www.google.co.uk", as_object=True)
 
-    **New behaviour**
+    **Old behaviour**
 
     .. code-block:: text
 
@@ -51,7 +51,7 @@ are used for versioning (schema follows below):
         In: res.tld
         Out: 'google.co.uk'
 
-    **Old behaviour**
+    **New behaviour**
 
     .. code-block:: text
 


### PR DESCRIPTION
The *New behaviour* and *Old behaviour* are swapped, which confused me for half an hour. This PR swaps them back to the correct place.