### PR TITLE
Fix #39 - correctly handling exceptions

### DIFF
--- a/src/tld/tests.py
+++ b/src/tld/tests.py
@@ -226,6 +226,24 @@ class TldTest(unittest.TestCase):
                 'tld': u'سوريا',
                 'kwargs': {'fail_silently': True, 'fix_protocol': True},
             },
+            {
+                'url': u'http://www.help.kawasaki.jp',
+                'fld': u'www.help.kawasaki.jp',
+                'subdomain': '',
+                'domain': 'www',
+                'suffix': u'help.kawasaki.jp',
+                'tld': u'help.kawasaki.jp',
+                'kwargs': {'fail_silently': True},
+            },
+            {
+                'url': u'http://www.city.kawasaki.jp',
+                'fld': u'city.kawasaki.jp',
+                'subdomain': 'www',
+                'domain': 'city',
+                'suffix': u'kawasaki.jp',
+                'tld': u'kawasaki.jp',
+                'kwargs': {'fail_silently': True},
+            },
         ]
 
         self.bad_patterns = {

--- a/src/tld/utils.py
+++ b/src/tld/utils.py
@@ -74,10 +74,11 @@ class Result(object):
 class TrieNode(object):
     """Class representing a single Trie node."""
 
-    __slots__ = ('children', 'leaf', 'private')
+    __slots__ = ('children', 'exception', 'leaf', 'private')
 
     def __init__(self):
         self.children = None
+        self.exception = None
         self.leaf = False
         self.private = False
 
@@ -97,6 +98,10 @@ class Trie(object):
 
         # Iterating over the tld parts in reverse order
         for part in reversed(tld.split('.')):
+
+            if part.startswith('!'):
+                node.exception = part[1:]
+                break
 
             # To save up some RAM, we initialize the children dict only
             # when strictly necessary
@@ -279,15 +284,15 @@ def process_url(url,
         if node.children is None:
             break
 
+        # Exception
+        if part == node.exception:
+            break
+
         child = node.children.get(part)
 
         # Wildcards
         if child is None:
             child = node.children.get('*')
-
-        # Inactive
-        if active_only is False and child is None:
-            child = node.children.get('!{0}'.format(part))
 
         # If the current part is not in current node's children, we can stop
         if child is None:


### PR DESCRIPTION
@barseghyanartur fixing exceptions handling as mentioned in #39.

Two remarks:

1. Should we drop the `active_only` option since it does not have a purpose anymore?
2. Since it's the case right now, I assumed one node can only have a single exception. It might not be completely future-proof.