### PR TITLE
setup.py: fix test suite specifier

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ are used for versioning (schema follows below):
 - Correctly handling exceptions (!) in the original TLD list.
 - Fixes in documentation.
 - Added ``parse_tld`` function.
+- Fixes the ``python setup.py test`` command.
 
 0.8
 ---

--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,5 @@ setup(
     install_requires=[
         'six>=1.9'
     ],
-    test_suite='src/tld/tests.py',
+    test_suite='tld.tests',
 )


### PR DESCRIPTION
filenames are not supported. one must use the module name inside the package