### PR TITLE
Fix an issuing causing certain punycode TLDs to be deemed invalid

### DIFF
--- a/src/tld/utils.py
+++ b/src/tld/utils.py
@@ -214,7 +214,7 @@ def get_tld_names(fail_silently=False, retry_count=0):
 
             # Puny code tlds
             if '// xn--' in line:
-                line = line.split(' (', 1)[0][3:]
+                line = line.split()[1]
 
             if line[0] == '/' or line[0] == '\n':
                 continue


### PR DESCRIPTION
The part of the parser that extracts punycode TLDs expects
them to be formatted similar to:

// xn--mgbaam7a8h ("Emerat", Arabic) : AE

but some look like:

// xn--11b4c3d : 2015-01-15 VeriSign Sarl

This commit changes the parsing logic to just extract the
second whitespace delimited token on these lines, which works
in both cases.  This enables support for an additional 93
punycode domains