### PR TITLE
Adding .python-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /htmlcov/
 *.py,cover
 .pytest_cache
+.python-version
 .idea/
 .ipynb_checkpoints/
 /deb_dist/


### PR DESCRIPTION
Hello @barseghyanartur,

Just starting to work on some PRs for the lib right now. Just a very basic .gitignore change to avoid committing `.python-version` file (very handy with `pyenv`).

More coming soon :)

Have a good day