### PR TITLE
`process_url` now also accepts already splitted urls

### DIFF
--- a/src/tld/res/effective_tld_names.dat.txt
+++ b/src/tld/res/effective_tld_names.dat.txt
@@ -6038,14 +6038,27 @@ org.sn
 perso.sn
 univ.sn
 
-// so : http://www.soregistry.com/
+// so : http://sonic.so/policies/
 so
 com.so
+edu.so
+gov.so
+me.so
 net.so
 org.so
 
 // sr : https://en.wikipedia.org/wiki/.sr
 sr
+
+// ss : https://registry.nic.ss/
+// Submitted by registry <technical@nic.ss>
+ss
+biz.ss
+com.ss
+edu.ss
+gov.ss
+net.ss
+org.ss
 
 // st : http://www.nic.st/html/policyrules/
 st
@@ -6789,6 +6802,9 @@ yt
 // xn--e1a4c ("eu", Cyrillic) : EU
 ею
 
+// xn--mgbah1a3hjkrd ("Mauritania", Arabic) : MR
+موريتانيا
+
 // xn--node ("ge", Georgian Mkhedruli) : GE
 გე
 
@@ -7062,7 +7078,7 @@ org.zw
 
 // newGTLDs
 
-// List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2019-09-10T15:21:14Z
+// List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2019-10-24T16:58:26Z
 // This list is auto-generated, don't edit it manually.
 // aaa : 2015-02-26 American Automobile Association, Inc.
 aaa
@@ -9827,6 +9843,9 @@ sony
 // soy : 2014-01-23 Charleston Road Registry Inc.
 soy
 
+// spa : 2019-09-19 Asia Spa and Wellness Promotion Council Limited
+spa
+
 // space : 2014-04-03 DotSpace Inc.
 space
 
@@ -10115,7 +10134,7 @@ unicom
 // university : 2014-03-06 Binky Moon, LLC
 university
 
-// uno : 2013-09-11 Dot Latin LLC
+// uno : 2013-09-11 DotSite Inc.
 uno
 
 // uol : 2014-05-01 UBN INTERNET LTDA.
@@ -10346,7 +10365,7 @@ xin
 // xn--3bst00m : 2013-09-13 Eagle Horizon Limited
 集团
 
-// xn--3ds443g : 2013-09-08 TLD REGISTRY LIMITED
+// xn--3ds443g : 2013-09-08 TLD REGISTRY LIMITED OY
 在线
 
 // xn--3oq18vl8pn36a : 2015-07-02 Volkswagen (China) Investment Co., Ltd.
@@ -10424,7 +10443,7 @@ xin
 // xn--cg4bki : 2013-09-27 SAMSUNG SDS CO., LTD
 삼성
 
-// xn--czr694b : 2014-01-16 Dot Trademark TLD Holding Company Limited
+// xn--czr694b : 2014-01-16 Internet DotTrademark Organisation Limited
 商标
 
 // xn--czrs0t : 2013-12-19 Binky Moon, LLC
@@ -10451,7 +10470,7 @@ xin
 // xn--fhbei : 2015-01-15 VeriSign Sarl
 كوم
 
-// xn--fiq228c5hs : 2013-09-08 TLD REGISTRY LIMITED
+// xn--fiq228c5hs : 2013-09-08 TLD REGISTRY LIMITED OY
 中文网
 
 // xn--fiq64b : 2013-10-14 CITIC Group Corporation
@@ -10481,7 +10500,7 @@ xin
 // xn--i1b6b1a6a2e : 2013-11-14 Public Interest Registry
 संगठन
 
-// xn--imr513n : 2014-12-11 Dot Trademark TLD Holding Company Limited
+// xn--imr513n : 2014-12-11 Internet DotTrademark Organisation Limited
 餐厅
 
 // xn--io0a7i : 2013-11-14 China Internet Network Information Center (CNNIC)
@@ -10550,7 +10569,7 @@ xin
 // xn--nyqy26a : 2014-11-07 Stable Tone Limited
 健康
 
-// xn--otu796d : 2017-08-06 Dot Trademark TLD Holding Company Limited
+// xn--otu796d : 2017-08-06 Internet DotTrademark Organisation Limited
 招聘
 
 // xn--p1acf : 2013-12-12 Rusnames Limited
@@ -10687,6 +10706,10 @@ barsy.ca
 // Submitted by Mark J. Titorenko <mark.titorenko@alces-software.com>
 *.compute.estate
 *.alces.network
+
+// Altervista: https://www.altervista.org
+// Submitted by Carlo Cannas <tech_staff@altervista.it>
+altervista.org
 
 // alwaysdata : https://www.alwaysdata.com
 // Submitted by Cyril <admin@alwaysdata.com>
@@ -11769,6 +11792,10 @@ gitlab.io
 // Glitch, Inc : https://glitch.com
 // Submitted by Mads Hartmann <mads@glitch.com>
 glitch.me
+
+// GMO Pepabo, Inc. : https://pepabo.com/
+// Submitted by dojineko <admin@pepabo.com>
+lolipop.io
 
 // GOV.UK Platform as a Service : https://www.cloud.service.gov.uk/
 // Submitted by Tom Whitwell <tom.whitwell@digital.cabinet-office.gov.uk>

--- a/src/tld/tests/test_core.py
+++ b/src/tld/tests/test_core.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import six
+from six.moves.urllib.parse import urlsplit
 
 from .. import defaults
 from ..conf import get_setting, reset_settings, set_setting
@@ -259,6 +260,15 @@ class TestCore(unittest.TestCase):
                 'suffix': 'xn--11b4c3d',
                 'tld': 'xn--11b4c3d',
                 'kwargs': {'fail_silently': True},
+            },
+            {
+                'url': urlsplit('http://lemonde.fr/article.html'),
+                'fld': 'lemonde.fr',
+                'subdomain': '',
+                'domain': 'lemonde',
+                'suffix': 'fr',
+                'tld': 'fr',
+                'kwargs': {'fail_silently': True}
             },
         ]
 

--- a/src/tld/utils.py
+++ b/src/tld/utils.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import codecs
 
 from six import PY3, text_type
-from six.moves.urllib.parse import urlsplit
+from six.moves.urllib.parse import urlsplit, SplitResult
 from six.moves.urllib.request import urlopen
 
 from .conf import get_setting
@@ -273,19 +273,23 @@ def process_url(url,
             "set to True."
         )
 
-    url = url.lower()
-
-    if fix_protocol:
-        if (
-            not url.startswith('//')
-            and not (url.startswith('http://') or url.startswith('https://'))
-        ):
-            url = 'https://{}'.format(url)
-
     tld_names = get_tld_names(fail_silently=fail_silently)  # Init
 
-    # Get parsed URL as we might need it later
-    parsed_url = urlsplit(url)
+    if not isinstance(url, SplitResult):
+        url = url.lower()
+
+        if fix_protocol:
+            if (
+                not url.startswith('//')
+                and not (url.startswith('http://') or url.startswith('https://'))
+            ):
+                url = 'https://{}'.format(url)
+
+        # Get parsed URL as we might need it later
+        parsed_url = urlsplit(url)
+    else:
+        parsed_url = url
+
     # Get (sub) domain name
     domain_name = parsed_url.netloc
 


### PR DESCRIPTION
Hello again @barseghyanartur,

Just a little PR enabling users to give an already splitted url to the `process_url`  function. I need this because in some of my use case the url is already splitted and, for performance reasons, it should not be required to split it again.

Note that it also updates the default tld names dat file.