### PR TITLE
Packages: add test files to source dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ include CREDITS.rst
 include LICENSE_GPL2.0.txt
 include LICENSE_LGPL_2.1.txt
 graft docs/
+graft src/tld/tests/res/


### PR DESCRIPTION
The test resources are necessary to run the tests successfully and should be part of the source distribution tarball