### PR TITLE
Use public suffix list instead of Mozilla's

### DIFF
--- a/src/tld/utils.py
+++ b/src/tld/utils.py
@@ -266,8 +266,7 @@ class MozillaTLDSourceParser(BaseMozillaTLDSourceParser):
     """Mozilla TLD source."""
 
     uid: str = 'mozilla'
-    source_url: str = 'http://mxr.mozilla.org/mozilla/source/netwerk/' \
-                      'dns/src/effective_tld_names.dat?raw=1'
+    source_url: str = 'https://publicsuffix.org/list/public_suffix_list.dat'
     local_path: str = 'res/effective_tld_names.dat.txt'
 
 # **************************************************************************


### PR DESCRIPTION
According to https://mxr.mozilla.org/, it should not be used for hotlinking and the http version is timing out as of yesterday.

According to https://wiki.mozilla.org/Public_Suffix_List, we should use the data from https://publicsuffix.org/ which exposes a list for public consumption at https://publicsuffix.org/list/public_suffix_list.dat

I just replaced the URL in `tld` and ran the tests. Everything appears to work but I'm not sure about any subtleties which may come along with the change.

I did not find a contributors guideline, so I'm not sure if anything else is required to make it land.
Also, please let me know if you'd like me to also update the class names to remove Mozilla from it as it is not used anymore.