### PR TITLE
Adding support for new Brazilian TLDs

### DIFF
--- a/examples/gae/data.py
+++ b/examples/gae/data.py
@@ -444,8 +444,20 @@ tksat.bo
 transporte.bo
 wiki.bo
 
-// br : http://registro.br/dominio/categoria.html
+// br : http://registro.br/dominio/categorias
 // Submitted by registry <fneves@registro.br>
+app.br
+dev.br
+log.br
+seg.br
+tec.br
+bib.br
+coz.br
+des.br
+det.br
+enf.br
+geo.br
+rep.br
 br
 9guacu.br
 abc.br

--- a/examples/gae/data.py
+++ b/examples/gae/data.py
@@ -444,8 +444,9 @@ tksat.bo
 transporte.bo
 wiki.bo
 
-// br : http://registro.br/dominio/categorias
+// br : https://registro.br/dominio/categorias/
 // Submitted by registry <fneves@registro.br>
+
 app.br
 dev.br
 log.br

--- a/src/tld/res/effective_tld_names.dat.txt
+++ b/src/tld/res/effective_tld_names.dat.txt
@@ -444,8 +444,21 @@ tksat.bo
 transporte.bo
 wiki.bo
 
-// br : http://registro.br/dominio/categoria.html
+// br : http://registro.br/dominio/categorias
 // Submitted by registry <fneves@registro.br>
+
+app.br
+dev.br
+log.br
+seg.br
+tec.br
+bib.br
+coz.br
+des.br
+det.br
+enf.br
+geo.br
+rep.br
 br
 9guacu.br
 abc.br

--- a/src/tld/res/effective_tld_names.dat.txt
+++ b/src/tld/res/effective_tld_names.dat.txt
@@ -444,7 +444,7 @@ tksat.bo
 transporte.bo
 wiki.bo
 
-// br : http://registro.br/dominio/categorias
+// br : https://registro.br/dominio/categorias/
 // Submitted by registry <fneves@registro.br>
 
 app.br

--- a/src/tld/tests/res/effective_tld_names_custom.dat.txt
+++ b/src/tld/tests/res/effective_tld_names_custom.dat.txt
@@ -449,6 +449,7 @@ wiki.bo
 
 // br : https://registro.br/dominio/categorias/
 // Submitted by registry <fneves@registro.br>
+
 app.br
 dev.br
 log.br

--- a/src/tld/tests/res/effective_tld_names_custom.dat.txt
+++ b/src/tld/tests/res/effective_tld_names_custom.dat.txt
@@ -447,8 +447,20 @@ tksat.bo
 transporte.bo
 wiki.bo
 
-// br : http://registro.br/dominio/categoria.html
+// br : https://registro.br/dominio/categorias/
 // Submitted by registry <fneves@registro.br>
+app.br
+dev.br
+log.br
+seg.br
+tec.br
+bib.br
+coz.br
+des.br
+det.br
+enf.br
+geo.br
+rep.br
 br
 9guacu.br
 abc.br


### PR DESCRIPTION
In the 20 july 2020 the main Brazilian department responsible for national domains added new tlds to purchase domains, so this PR aims to add support to them.
You can check the official documentation in the link below.

References: https://registro.br/dominio/categorias/