### PR TITLE
Make sure to really fail silently

### DIFF
--- a/src/tld/tests/test_core.py
+++ b/src/tld/tests/test_core.py
@@ -842,3 +842,17 @@ class TestCore(unittest.TestCase):
                 fragment="",
             ),
         )
+
+    @log_info
+    def test_27_tld_fail_silently_pass(self):
+        """Test `get_tld` bad URL patterns that would raise exception if fail_silently isn't True."""
+        res = []
+        bad_url = [
+            'https://user:password[@host.com',
+            'https://user[@host.com'
+        ]
+        for url in bad_url:
+            _res = get_tld(url, fail_silently=True)
+            self.assertEqual(_res, None)
+            res.append(_res)
+        return res

--- a/src/tld/utils.py
+++ b/src/tld/utils.py
@@ -310,20 +310,24 @@ def process_url(
             url = f"https://{url}"
 
         # Get parsed URL as we might need it later
-        parsed_url = urlsplit(url)
+        try:
+            parsed_url = urlsplit(url)
+        except ValueError as e:
+            if fail_silently:
+                parsed_url = url
+            else:
+                raise e
     else:
         parsed_url = url
 
     # Get (sub) domain name
-    domain_name = parsed_url.hostname
-
-    if not domain_name:
+    try:
+        domain_name = parsed_url.hostname
+    except AttributeError as e:
         if fail_silently:
-            return None, None, parsed_url
+            domain_name = None
         else:
-            raise TldBadUrl(url=url)
-
-    domain_name = domain_name.lower()
+            raise e
 
     # This will correctly handle dots at the end of domain name in URLs like
     # https://github.com............/barseghyanartur/tld/

--- a/src/tld/utils.py
+++ b/src/tld/utils.py
@@ -314,20 +314,22 @@ def process_url(
             parsed_url = urlsplit(url)
         except ValueError as e:
             if fail_silently:
-                parsed_url = url
+                return None, None, url
             else:
                 raise e
     else:
         parsed_url = url
 
     # Get (sub) domain name
-    try:
-        domain_name = parsed_url.hostname
-    except AttributeError as e:
+    domain_name = parsed_url.hostname
+
+    if not domain_name:
         if fail_silently:
-            domain_name = None
+            return None, None, parsed_url
         else:
-            raise e
+            raise TldBadUrl(url=url)
+
+    domain_name = domain_name.lower()
 
     # This will correctly handle dots at the end of domain name in URLs like
     # https://github.com............/barseghyanartur/tld/


### PR DESCRIPTION
Exemple: urlsplit() raising ValueError("Invalid IPv6 URL")