### PR TITLE
chore: use pytest-order instead of pytest-ordering and bump versions

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@
 #    uv pip compile pyproject.toml --all-extras -o docs/requirements.txt
 alabaster==1.0.0
     # via sphinx
-anyio==4.12.1
+anyio==4.13.0
     # via
     #   starlette
     #   watchfiles
@@ -10,15 +10,17 @@ asttokens==3.0.1
     # via stack-data
 babel==2.18.0
     # via sphinx
-build==1.4.0
+build==1.5.0
     # via tld (pyproject.toml)
-cachetools==7.0.3
+cachetools==7.1.4
     # via tox
-certifi==2026.2.25
+certifi==2026.5.20
     # via requests
-charset-normalizer==3.4.5
+cffi==2.0.0
+    # via cryptography
+charset-normalizer==3.4.7
     # via requests
-click==8.3.1
+click==8.4.1
     # via
     #   pydoclint
     #   uvicorn
@@ -26,15 +28,17 @@ colorama==0.4.6
     # via
     #   sphinx-autobuild
     #   tox
-coverage==7.13.4
+coverage==7.14.1
     # via
     #   tld (pyproject.toml)
     #   pytest-cov
-decorator==5.2.1
+cryptography==49.0.0
+    # via secretstorage
+decorator==5.3.1
     # via ipython
 detect-secrets==1.5.0
     # via tld (pyproject.toml)
-distlib==0.4.0
+distlib==0.4.3
     # via virtualenv
 doc8==2.0.0
     # via tld (pyproject.toml)
@@ -51,9 +55,9 @@ docutils==0.21.2
     #   sphinx-rtd-theme
 executing==2.2.1
     # via stack-data
-fake-py==0.12.2
+fake-py==0.13.1
     # via tld (pyproject.toml)
-filelock==3.25.0
+filelock==3.29.4
     # via
     #   python-discovery
     #   tox
@@ -62,7 +66,7 @@ h11==0.16.0
     # via uvicorn
 id==1.6.1
     # via twine
-idna==3.11
+idna==3.18
     # via
     #   anyio
     #   requests
@@ -70,37 +74,41 @@ imagesize==2.0.0
     # via sphinx
 iniconfig==2.3.0
     # via pytest
-ipython==9.11.0
+ipython==9.14.1
     # via tld (pyproject.toml)
 ipython-pygments-lexers==1.1.1
     # via ipython
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==6.1.0
+jaraco-context==6.1.2
     # via keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.5.0
     # via keyring
-jedi==0.19.2
+jedi==0.20.0
     # via ipython
+jeepney==0.9.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.6
     # via sphinx
 keyring==25.7.0
     # via twine
-markdown-it-py==4.0.0
+markdown-it-py==4.2.0
     # via rich
 markupsafe==3.0.3
     # via jinja2
-matplotlib-inline==0.2.1
+matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.3.3
+nh3==0.3.5
     # via readme-renderer
-packaging==26.0
+packaging==26.2
     # via
     #   build
     #   pyproject-api
@@ -109,13 +117,13 @@ packaging==26.0
     #   tox
     #   twine
     #   wheel
-parso==0.8.6
+parso==0.8.7
     # via jedi
 pexpect==4.9.0
     # via ipython
 pkginfo==1.12.1.2
     # via tld (pyproject.toml)
-platformdirs==4.9.4
+platformdirs==4.10.0
     # via
     #   python-discovery
     #   tox
@@ -127,13 +135,17 @@ pluggy==1.6.0
     #   tox
 prompt-toolkit==3.0.52
     # via ipython
+psutil==7.2.2
+    # via ipython
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pydoclint==0.8.3
+pycparser==3.0
+    # via cffi
+pydoclint==0.8.6
     # via tld (pyproject.toml)
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   doc8
     #   ipython
@@ -142,29 +154,31 @@ pygments==2.19.2
     #   readme-renderer
     #   rich
     #   sphinx
-pyproject-api==1.10.0
+pyproject-api==1.10.1
     # via tox
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.2
+pytest==9.1.0
     # via
     #   tld (pyproject.toml)
     #   pytest-codeblock
     #   pytest-cov
-    #   pytest-ordering
-pytest-codeblock==0.5.6
+    #   pytest-order
+pytest-codeblock==0.5.9
     # via tld (pyproject.toml)
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via tld (pyproject.toml)
-pytest-ordering==0.6
+pytest-order==1.5.0
     # via tld (pyproject.toml)
-python-discovery==1.1.0
-    # via virtualenv
+python-discovery==1.4.2
+    # via
+    #   tox
+    #   virtualenv
 pyyaml==6.0.3
     # via detect-secrets
-readme-renderer==44.0
+readme-renderer==45.0
     # via twine
-requests==2.32.5
+requests==2.34.2
     # via
     #   detect-secrets
     #   requests-toolbelt
@@ -176,13 +190,15 @@ restructuredtext-lint==2.0.2
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==14.3.3
+rich==15.0.0
     # via twine
 roman-numerals==4.1.0
     # via sphinx
-ruff==0.15.5
+ruff==0.15.17
     # via tld (pyproject.toml)
-snowballstemmer==3.0.1
+secretstorage==3.5.0
+    # via keyring
+snowballstemmer==3.1.1
     # via sphinx
 sphinx==9.1.0
     # via
@@ -218,42 +234,38 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 stack-data==0.6.3
     # via ipython
-starlette==0.52.1
+starlette==1.3.1
     # via sphinx-autobuild
-stevedore==5.7.0
+stevedore==5.8.0
     # via doc8
 tomli-w==1.2.0
     # via tox
-tox==4.49.0
+tox==4.55.1
     # via tld (pyproject.toml)
-traitlets==5.14.3
+traitlets==5.15.1
     # via
     #   ipython
     #   matplotlib-inline
 twine==6.2.0
     # via tld (pyproject.toml)
-ty==0.0.34
+ty==0.0.49
     # via tld (pyproject.toml)
-typing-extensions==4.15.0
-    # via
-    #   anyio
-    #   starlette
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   id
     #   requests
     #   twine
-uv==0.10.9
+uv==0.11.21
     # via tld (pyproject.toml)
-uvicorn==0.41.0
+uvicorn==0.49.0
     # via sphinx-autobuild
-virtualenv==21.1.0
+virtualenv==21.5.0
     # via tox
-watchfiles==1.1.1
+watchfiles==1.2.0
     # via sphinx-autobuild
-wcwidth==0.6.0
+wcwidth==0.8.1
     # via prompt-toolkit
 websockets==16.0
     # via sphinx-autobuild
-wheel==0.46.3
+wheel==0.47.0
     # via tld (pyproject.toml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ test = [
     "pytest",
     "pytest-codeblock",
     "pytest-cov",
-    "pytest-ordering",
+    "pytest-order",
     "tox",
 ]
 docs = [

--- a/requirements/bench.txt
+++ b/requirements/bench.txt
@@ -2,7 +2,7 @@
 #    uv pip compile pyproject.toml requirements/bench.in --all-extras -o requirements/bench.txt
 alabaster==1.0.0
     # via sphinx
-anyio==4.12.1
+anyio==4.13.0
     # via
     #   starlette
     #   watchfiles
@@ -10,15 +10,17 @@ asttokens==3.0.1
     # via stack-data
 babel==2.18.0
     # via sphinx
-build==1.4.0
+build==1.5.0
     # via tld (pyproject.toml)
-cachetools==7.0.3
+cachetools==7.1.4
     # via tox
-certifi==2026.2.25
+certifi==2026.5.20
     # via requests
-charset-normalizer==3.4.5
+cffi==2.0.0
+    # via cryptography
+charset-normalizer==3.4.7
     # via requests
-click==8.3.1
+click==8.4.1
     # via
     #   pydoclint
     #   uvicorn
@@ -28,17 +30,19 @@ colorama==0.4.6
     #   tox
 contourpy==1.3.3
     # via matplotlib
-coverage==7.13.4
+coverage==7.14.1
     # via
     #   tld (pyproject.toml)
     #   pytest-cov
+cryptography==49.0.0
+    # via secretstorage
 cycler==0.12.1
     # via matplotlib
-decorator==5.2.1
+decorator==5.3.1
     # via ipython
 detect-secrets==1.5.0
     # via tld (pyproject.toml)
-distlib==0.4.0
+distlib==0.4.3
     # via virtualenv
 doc8==2.0.0
     # via tld (pyproject.toml)
@@ -55,14 +59,14 @@ docutils==0.21.2
     #   sphinx-rtd-theme
 executing==2.2.1
     # via stack-data
-fake-py==0.12.2
+fake-py==0.13.1
     # via tld (pyproject.toml)
-filelock==3.25.0
+filelock==3.29.4
     # via
     #   python-discovery
     #   tox
     #   virtualenv
-fonttools==4.61.1
+fonttools==4.63.0
     # via matplotlib
 gprof2dot==2025.4.14
     # via pytest-profiling
@@ -70,7 +74,7 @@ h11==0.16.0
     # via uvicorn
 id==1.6.1
     # via twine
-idna==3.11
+idna==3.18
     # via
     #   anyio
     #   requests
@@ -78,49 +82,53 @@ imagesize==2.0.0
     # via sphinx
 iniconfig==2.3.0
     # via pytest
-ipython==9.11.0
+ipython==9.14.1
     # via tld (pyproject.toml)
 ipython-pygments-lexers==1.1.1
     # via ipython
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==6.1.0
+jaraco-context==6.1.2
     # via keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.5.0
     # via keyring
-jedi==0.19.2
+jedi==0.20.0
     # via ipython
+jeepney==0.9.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.6
     # via sphinx
 keyring==25.7.0
     # via twine
-kiwisolver==1.4.9
+kiwisolver==1.5.0
     # via matplotlib
 line-profiler==5.0.2
     # via -r requirements/bench.in
-markdown-it-py==4.0.0
+markdown-it-py==4.2.0
     # via rich
 markupsafe==3.0.3
     # via jinja2
-matplotlib==3.10.8
+matplotlib==3.11.0
     # via -r requirements/bench.in
-matplotlib-inline==0.2.1
+matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
 memory-profiler==0.61.0
     # via -r requirements/bench.in
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.3.3
+nh3==0.3.5
     # via readme-renderer
-numpy==2.4.2
+numpy==2.4.6
     # via
     #   contourpy
     #   matplotlib
-packaging==26.0
+packaging==26.2
     # via
     #   build
     #   matplotlib
@@ -130,15 +138,15 @@ packaging==26.0
     #   tox
     #   twine
     #   wheel
-parso==0.8.6
+parso==0.8.7
     # via jedi
 pexpect==4.9.0
     # via ipython
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
 pkginfo==1.12.1.2
     # via tld (pyproject.toml)
-platformdirs==4.9.4
+platformdirs==4.10.0
     # via
     #   python-discovery
     #   tox
@@ -151,18 +159,22 @@ pluggy==1.6.0
 prompt-toolkit==3.0.52
     # via ipython
 psutil==7.2.2
-    # via memory-profiler
+    # via
+    #   ipython
+    #   memory-profiler
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-py-spy==0.4.1
+py-spy==0.4.2
     # via -r requirements/bench.in
 pycallgraph2==1.1.3
     # via -r requirements/bench.in
-pydoclint==0.8.3
+pycparser==3.0
+    # via cffi
+pydoclint==0.8.6
     # via tld (pyproject.toml)
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   doc8
     #   ipython
@@ -175,34 +187,36 @@ pyparsing==3.3.2
     # via matplotlib
 pyprof2calltree==1.4.5
     # via -r requirements/bench.in
-pyproject-api==1.10.0
+pyproject-api==1.10.1
     # via tox
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.2
+pytest==9.1.0
     # via
     #   tld (pyproject.toml)
     #   pytest-codeblock
     #   pytest-cov
-    #   pytest-ordering
+    #   pytest-order
     #   pytest-profiling
-pytest-codeblock==0.5.6
+pytest-codeblock==0.5.9
     # via tld (pyproject.toml)
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via tld (pyproject.toml)
-pytest-ordering==0.6
+pytest-order==1.5.0
     # via tld (pyproject.toml)
 pytest-profiling==1.8.1
     # via -r requirements/bench.in
 python-dateutil==2.9.0.post0
     # via matplotlib
-python-discovery==1.1.0
-    # via virtualenv
+python-discovery==1.4.2
+    # via
+    #   tox
+    #   virtualenv
 pyyaml==6.0.3
     # via detect-secrets
-readme-renderer==44.0
+readme-renderer==45.0
     # via twine
-requests==2.32.5
+requests==2.34.2
     # via
     #   detect-secrets
     #   requests-toolbelt
@@ -214,17 +228,19 @@ restructuredtext-lint==2.0.2
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==14.3.3
+rich==15.0.0
     # via twine
 roman-numerals==4.1.0
     # via sphinx
-ruff==0.15.5
+ruff==0.15.17
     # via tld (pyproject.toml)
+secretstorage==3.5.0
+    # via keyring
 six==1.17.0
     # via
     #   pytest-profiling
     #   python-dateutil
-snowballstemmer==3.0.1
+snowballstemmer==3.1.1
     # via sphinx
 sphinx==9.1.0
     # via
@@ -260,43 +276,40 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 stack-data==0.6.3
     # via ipython
-starlette==0.52.1
+starlette==1.3.1
     # via sphinx-autobuild
-stevedore==5.7.0
+stevedore==5.8.0
     # via doc8
 tomli-w==1.2.0
     # via tox
-tox==4.49.0
+tox==4.55.1
     # via tld (pyproject.toml)
-traitlets==5.14.3
+traitlets==5.15.1
     # via
     #   ipython
     #   matplotlib-inline
 twine==6.2.0
     # via tld (pyproject.toml)
-ty==0.0.34
+ty==0.0.49
     # via tld (pyproject.toml)
 typing-extensions==4.15.0
-    # via
-    #   anyio
-    #   line-profiler
-    #   starlette
-urllib3==2.6.3
+    # via line-profiler
+urllib3==2.7.0
     # via
     #   id
     #   requests
     #   twine
-uv==0.10.9
+uv==0.11.21
     # via tld (pyproject.toml)
-uvicorn==0.41.0
+uvicorn==0.49.0
     # via sphinx-autobuild
-virtualenv==21.1.0
+virtualenv==21.5.0
     # via tox
-watchfiles==1.1.1
+watchfiles==1.2.0
     # via sphinx-autobuild
-wcwidth==0.6.0
+wcwidth==0.8.1
     # via prompt-toolkit
 websockets==16.0
     # via sphinx-autobuild
-wheel==0.46.3
+wheel==0.47.0
     # via tld (pyproject.toml)

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,7 +2,7 @@
 #    uv pip compile pyproject.toml requirements/build.in --all-extras -o requirements/build.txt
 alabaster==1.0.0
     # via sphinx
-anyio==4.12.1
+anyio==4.13.0
     # via
     #   starlette
     #   watchfiles
@@ -10,15 +10,17 @@ asttokens==3.0.1
     # via stack-data
 babel==2.18.0
     # via sphinx
-build==1.4.0
+build==1.5.0
     # via tld (pyproject.toml)
-cachetools==7.0.3
+cachetools==7.1.4
     # via tox
-certifi==2026.2.25
+certifi==2026.5.20
     # via requests
-charset-normalizer==3.4.5
+cffi==2.0.0
+    # via cryptography
+charset-normalizer==3.4.7
     # via requests
-click==8.3.1
+click==8.4.1
     # via
     #   pydoclint
     #   uvicorn
@@ -26,15 +28,17 @@ colorama==0.4.6
     # via
     #   sphinx-autobuild
     #   tox
-coverage==7.13.4
+coverage==7.14.1
     # via
     #   tld (pyproject.toml)
     #   pytest-cov
-decorator==5.2.1
+cryptography==49.0.0
+    # via secretstorage
+decorator==5.3.1
     # via ipython
 detect-secrets==1.5.0
     # via tld (pyproject.toml)
-distlib==0.4.0
+distlib==0.4.3
     # via virtualenv
 doc8==2.0.0
     # via tld (pyproject.toml)
@@ -51,9 +55,9 @@ docutils==0.21.2
     #   sphinx-rtd-theme
 executing==2.2.1
     # via stack-data
-fake-py==0.12.2
+fake-py==0.13.1
     # via tld (pyproject.toml)
-filelock==3.25.0
+filelock==3.29.4
     # via
     #   python-discovery
     #   tox
@@ -62,7 +66,7 @@ h11==0.16.0
     # via uvicorn
 id==1.6.1
     # via twine
-idna==3.11
+idna==3.18
     # via
     #   anyio
     #   requests
@@ -70,37 +74,41 @@ imagesize==2.0.0
     # via sphinx
 iniconfig==2.3.0
     # via pytest
-ipython==9.11.0
+ipython==9.14.1
     # via tld (pyproject.toml)
 ipython-pygments-lexers==1.1.1
     # via ipython
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==6.1.0
+jaraco-context==6.1.2
     # via keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.5.0
     # via keyring
-jedi==0.19.2
+jedi==0.20.0
     # via ipython
+jeepney==0.9.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.6
     # via sphinx
 keyring==25.7.0
     # via twine
-markdown-it-py==4.0.0
+markdown-it-py==4.2.0
     # via rich
 markupsafe==3.0.3
     # via jinja2
-matplotlib-inline==0.2.1
+matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.3.3
+nh3==0.3.5
     # via readme-renderer
-packaging==26.0
+packaging==26.2
     # via
     #   build
     #   pyproject-api
@@ -109,13 +117,13 @@ packaging==26.0
     #   tox
     #   twine
     #   wheel
-parso==0.8.6
+parso==0.8.7
     # via jedi
 pexpect==4.9.0
     # via ipython
 pkginfo==1.12.1.2
     # via tld (pyproject.toml)
-platformdirs==4.9.4
+platformdirs==4.10.0
     # via
     #   python-discovery
     #   tox
@@ -127,13 +135,17 @@ pluggy==1.6.0
     #   tox
 prompt-toolkit==3.0.52
     # via ipython
+psutil==7.2.2
+    # via ipython
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pydoclint==0.8.3
+pycparser==3.0
+    # via cffi
+pydoclint==0.8.6
     # via tld (pyproject.toml)
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   doc8
     #   ipython
@@ -142,29 +154,31 @@ pygments==2.19.2
     #   readme-renderer
     #   rich
     #   sphinx
-pyproject-api==1.10.0
+pyproject-api==1.10.1
     # via tox
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.2
+pytest==9.1.0
     # via
     #   tld (pyproject.toml)
     #   pytest-codeblock
     #   pytest-cov
-    #   pytest-ordering
-pytest-codeblock==0.5.6
+    #   pytest-order
+pytest-codeblock==0.5.9
     # via tld (pyproject.toml)
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via tld (pyproject.toml)
-pytest-ordering==0.6
+pytest-order==1.5.0
     # via tld (pyproject.toml)
-python-discovery==1.1.0
-    # via virtualenv
+python-discovery==1.4.2
+    # via
+    #   tox
+    #   virtualenv
 pyyaml==6.0.3
     # via detect-secrets
-readme-renderer==44.0
+readme-renderer==45.0
     # via twine
-requests==2.32.5
+requests==2.34.2
     # via
     #   detect-secrets
     #   requests-toolbelt
@@ -176,13 +190,15 @@ restructuredtext-lint==2.0.2
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==14.3.3
+rich==15.0.0
     # via twine
 roman-numerals==4.1.0
     # via sphinx
-ruff==0.15.5
+ruff==0.15.17
     # via tld (pyproject.toml)
-snowballstemmer==3.0.1
+secretstorage==3.5.0
+    # via keyring
+snowballstemmer==3.1.1
     # via sphinx
 sphinx==9.1.0
     # via
@@ -218,44 +234,40 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 stack-data==0.6.3
     # via ipython
-starlette==0.52.1
+starlette==1.3.1
     # via sphinx-autobuild
 stdeb==0.11.0
     # via -r requirements/build.in
-stevedore==5.7.0
+stevedore==5.8.0
     # via doc8
 tomli-w==1.2.0
     # via tox
-tox==4.49.0
+tox==4.55.1
     # via tld (pyproject.toml)
-traitlets==5.14.3
+traitlets==5.15.1
     # via
     #   ipython
     #   matplotlib-inline
 twine==6.2.0
     # via tld (pyproject.toml)
-ty==0.0.34
+ty==0.0.49
     # via tld (pyproject.toml)
-typing-extensions==4.15.0
-    # via
-    #   anyio
-    #   starlette
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   id
     #   requests
     #   twine
-uv==0.10.9
+uv==0.11.21
     # via tld (pyproject.toml)
-uvicorn==0.41.0
+uvicorn==0.49.0
     # via sphinx-autobuild
-virtualenv==21.1.0
+virtualenv==21.5.0
     # via tox
-watchfiles==1.1.1
+watchfiles==1.2.0
     # via sphinx-autobuild
-wcwidth==0.6.0
+wcwidth==0.8.1
     # via prompt-toolkit
 websockets==16.0
     # via sphinx-autobuild
-wheel==0.46.3
+wheel==0.47.0
     # via tld (pyproject.toml)


### PR DESCRIPTION
As `pytest-ordering` [is deprecated in favor of](https://github.com/ftobia/pytest-ordering/tree/develop) (it's fork) `pytest-order,` we should use that one.
With that, all other dependencies are updated as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build, testing, and documentation tooling dependencies to latest versions, including security-related packages (cryptography, certifi, urllib3) and core framework dependencies (Starlette)
  * Refreshed dependency lock files to reflect current package ecosystem state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->